### PR TITLE
Fix filter config loading and event deletion

### DIFF
--- a/EventTracing/EventData.h
+++ b/EventTracing/EventData.h
@@ -67,7 +67,8 @@ protected:
 
 private:
 	inline static HANDLE s_hHeap = nullptr;
-	inline static uint32_t s_Count = 0;
+	inline static CRITICAL_SECTION s_HeapLock = {0};
+	inline static volatile uint32_t s_Count = 0;
 
 	ULONG _threadId, _processId;
 	EVENT_DESCRIPTOR _eventDescriptor;

--- a/ProcMonX/FilterConfiguration.cpp
+++ b/ProcMonX/FilterConfiguration.cpp
@@ -68,7 +68,7 @@ bool FilterConfiguration::Load(PCWSTR path) {
     for (int i = 1;; i++) {
         text.Format(L"Filter%d", i);
         auto name = file.ReadString(text, L"Type");
-        if (name.IsEmpty())
+        if (name.IsEmpty() || name == L"")
             break;
         FilterDescription desc;
         desc.Name = name;
@@ -76,7 +76,7 @@ bool FilterConfiguration::Load(PCWSTR path) {
         desc.DefaultAction = (FilterAction)file.ReadInt(text, L"DefaultAction");
         desc.Enabled = file.ReadBool(text, L"Enabled", true);
         desc.Parameters = file.ReadString(text, L"Parameters");
-
+        AddFilter(desc);
     }
     return true;
 }


### PR DESCRIPTION
These changes fix two bugs:

- Filter configuration loading bug caused by failure to add filter to filters list.
- Event data creation/deletion not synchronized which caused heap corruption.