### PR TITLE
Add CSV Save functionality

### DIFF
--- a/ProcMonX/CSVEventDataSerializer.cpp
+++ b/ProcMonX/CSVEventDataSerializer.cpp
@@ -5,7 +5,7 @@
 #include "FormatHelper.h"
 
 
-//  Needed for processes like msedge which contain commans in their command line, messing up the csv formatting
+//  Needed for processes like msedge which contain commas in their command line, messing up the csv formatting
 std::wstring CSVEventDataSerializer::EscapeCommandLine(std::wstring cmd)
 {
     std::wstring escapedCmd = L"";

--- a/ProcMonX/CSVEventDataSerializer.cpp
+++ b/ProcMonX/CSVEventDataSerializer.cpp
@@ -1,16 +1,63 @@
 #include "pch.h"
 #include "CSVEventDataSerializer.h"
 #include <fstream>
+#include <format>
+#include "FormatHelper.h"
+
+
+//  Needed for processes like msedge which contain commans in their command line, messing up the csv formatting
+std::wstring CSVEventDataSerializer::EscapeCommandLine(std::wstring cmd)
+{
+    std::wstring escapedCmd = L"";
+    for (wchar_t c : cmd)
+    {
+        if (c == '\"')
+        {
+            escapedCmd += c;
+        }
+        escapedCmd += c;
+    }
+
+    return std::format(L"\"{}\"", escapedCmd);
+}
+
+std::wstring CSVEventDataSerializer::SerializeEvent(std::shared_ptr<EventData>& event)
+{
+    std::wstring ts = (std::wstring)FormatHelper::FormatTime(event->GetTimeStamp());
+    std::wstring name = event->GetEventName();
+    std::wstring cmd, status, parentId = L"";
+    CString img = L"";
+
+    if (name == L"Process/Start" || name == L"Process/End")
+    {
+        cmd = (std::wstring)(event->GetProperty(L"CommandLine")->GetUnicodeString());
+        img = event->GetProperty(L"ImageFileName")->GetAnsiString();
+        status = std::to_wstring(event->GetProperty(L"ExitStatus")->GetValue<DWORD>());
+        parentId = std::to_wstring(event->GetProperty(L"ParentId")->GetValue<DWORD>());
+    }
+
+    std::wstring serial = std::format(L"{},{},{},{},{},{},{},{},{},{}", event->GetIndex(), ts, name, 
+                                      event->GetProcessName(), event->GetProcessId(), event->GetThreadId(),
+                                      EscapeCommandLine(cmd), (std::wstring)img, status, parentId);
+    
+    return serial;
+}
 
 bool CSVEventDataSerializer::Save(const std::vector<std::shared_ptr<EventData>>& events, const EventDataSerializerOptions& options, PCWSTR path) {
-    std::ofstream out;
+    std::wofstream out;
     out.open(path);
     if(out.fail())
         return false;
 
-    for (auto& evt : events) {
+    out << L"Id,Time Stamp,Event Name,Process Name,PID,TID,Command Line,Image Name,Exit Status,Parent ID" << std::endl;
+
+    for (std::shared_ptr<EventData> evt : events) {
+        out << SerializeEvent(evt) << std::endl;
     }
-    return false;
+
+    out.close();
+
+    return true;
 }
 
 std::vector<std::shared_ptr<EventData>> CSVEventDataSerializer::Load(PCWSTR path) {

--- a/ProcMonX/CSVEventDataSerializer.cpp
+++ b/ProcMonX/CSVEventDataSerializer.cpp
@@ -1,9 +1,8 @@
 #include "pch.h"
 #include "CSVEventDataSerializer.h"
+#include "FormatHelper.h"
 #include <fstream>
 #include <format>
-#include "FormatHelper.h"
-#include <chrono>
 
 //  Needed for processes like msedge which contain commas in their command line, messing up the csv formatting
 void CSVEventDataSerializer::EscapeCsvString(std::wstring& str)

--- a/ProcMonX/CSVEventDataSerializer.cpp
+++ b/ProcMonX/CSVEventDataSerializer.cpp
@@ -7,9 +7,10 @@
 //  Needed for processes like msedge which contain commas in their command line, messing up the csv formatting
 void CSVEventDataSerializer::EscapeCsvString(std::wstring& str)
 {
-    if (str.empty())
-		return; 
-    
+    if (str.empty()) {
+    	return; 
+    }
+
     std::wstring escapedStr = L"";
     for (wchar_t c : str) {
         if (c == '\"') {
@@ -23,18 +24,18 @@ void CSVEventDataSerializer::EscapeCsvString(std::wstring& str)
 
 std::wstring CSVEventDataSerializer::SerializeEvent(std::shared_ptr<EventData>& event)
 {
-	uint32_t index = event->GetIndex();
+    uint32_t index = event->GetIndex();
     DWORD tPid = event->GetProcessId();
     DWORD tTid = event->GetThreadId();
 
     std::wstring ts = (std::wstring)FormatHelper::FormatTime(event->GetTimeStamp());
     std::wstring name = event->GetEventName();
-	std::wstring pName = event->GetProcessName();
+    std::wstring pName = event->GetProcessName();
     std::wstring pid = (tPid == (DWORD) - 1) ? L"" : std::to_wstring(tPid);
     std::wstring tid = (tTid == (DWORD) - 1) ? L"" : std::to_wstring(tTid);
     std::wstring details = L"";
 
-	std::vector<EventProperty> props = event->GetProperties();
+    std::vector<EventProperty> props = event->GetProperties();
 
     if (props.size() > 0) {
         bool needsEscaping = false;
@@ -45,14 +46,14 @@ std::wstring CSVEventDataSerializer::SerializeEvent(std::shared_ptr<EventData>& 
                 if (p.Name == L"CommandLine") {
                     needsEscaping = true;
                 }
-            }            
+            }      
         }
 
-        if (needsEscaping) {
-            EscapeCsvString(details);
-        }
-	}    
-    
+	if (needsEscaping) {
+	    EscapeCsvString(details);
+	}
+    }
+
     return std::format(L"{},{},{},{},{},{},{}", index, ts, name, pName, pid, tid, details);
 }
 

--- a/ProcMonX/CSVEventDataSerializer.h
+++ b/ProcMonX/CSVEventDataSerializer.h
@@ -3,8 +3,8 @@
 
 class CSVEventDataSerializer : public IEventDataSerializer {
 private:
+	void EscapeCsvString(std::wstring& str);
 	std::wstring SerializeEvent(std::shared_ptr<EventData>& event);
-	std::wstring EscapeCommandLine(std::wstring cmd);
 public:
 	virtual bool Save(const std::vector<std::shared_ptr<EventData>>& events, const EventDataSerializerOptions& options, PCWSTR path) override;
 	virtual std::vector<std::shared_ptr<EventData>> Load(PCWSTR path) override;

--- a/ProcMonX/CSVEventDataSerializer.h
+++ b/ProcMonX/CSVEventDataSerializer.h
@@ -7,6 +7,6 @@ private:
 	std::wstring EscapeCommandLine(std::wstring cmd);
 public:
 	virtual bool Save(const std::vector<std::shared_ptr<EventData>>& events, const EventDataSerializerOptions& options, PCWSTR path) override;
-	virtual std::vector<std::shared_ptr<EventData>> Load(PCWSTR path) override;	
+	virtual std::vector<std::shared_ptr<EventData>> Load(PCWSTR path) override;
 };
 

--- a/ProcMonX/CSVEventDataSerializer.h
+++ b/ProcMonX/CSVEventDataSerializer.h
@@ -2,8 +2,11 @@
 #include "IEventDataSerializer.h"
 
 class CSVEventDataSerializer : public IEventDataSerializer {
+private:
+	std::wstring SerializeEvent(std::shared_ptr<EventData>& event);
+	std::wstring EscapeCommandLine(std::wstring cmd);
 public:
 	virtual bool Save(const std::vector<std::shared_ptr<EventData>>& events, const EventDataSerializerOptions& options, PCWSTR path) override;
-	virtual std::vector<std::shared_ptr<EventData>> Load(PCWSTR path) override;
+	virtual std::vector<std::shared_ptr<EventData>> Load(PCWSTR path) override;	
 };
 

--- a/ProcMonX/View.cpp
+++ b/ProcMonX/View.cpp
@@ -489,6 +489,8 @@ LRESULT CView::OnSave(WORD, WORD, HWND, BOOL&) {
 				auto eventsCopy = m_OrgEvents;
 				if (!serializer->Save(eventsCopy, options, dlg.m_szFileName))
 					AtlMessageBox(*this, L"Failed to save data", IDS_TITLE, MB_ICONERROR);
+				else
+					AtlMessageBox(*this, L"CSV Data saved successfully", IDS_TITLE, MB_ICONINFORMATION);
 				return 0;
 			}
 		}


### PR DESCRIPTION
Rough implementation of CSV serialization using std::format
Resolves #12

Performance: 50 - 70 seconds to save ~500 000 events (80 mb file) - considerably faster than PMK but contains no stack information

![image](https://github.com/user-attachments/assets/319141ac-53b3-4c34-98eb-21dd9fec8d64)